### PR TITLE
default argument order fix

### DIFF
--- a/tests/json.py
+++ b/tests/json.py
@@ -4,8 +4,9 @@ import jsonrpclib
 import unittest
 
 class TestJSONHandler(TestHandler, JSONRPCHandler):
-    pass
-            
+    def testOrder(self, a=1, b=2, c=3):
+        return {'a': a, 'b': b, 'c': c}
+
 class JSONRPCTests(RPCTests, unittest.TestCase):
     port = 8003
     handler = TestJSONHandler
@@ -17,4 +18,15 @@ class JSONRPCTests(RPCTests, unittest.TestCase):
     def test_private(self):
         client = self.get_client()
         self.assertRaises(jsonrpclib.ProtocolError, client.private)
+
+    def test_order(self):
+        client = self.get_client()
+        self.assertEqual(client.testOrder(), 
+                         {'a': 1, 'b': 2, 'c': 3})
+        self.assertEqual(client.testOrder(a=10), 
+                         {'a': 10, 'b': 2, 'c': 3})
+        self.assertEqual(client.testOrder(c=10), 
+                         {'a': 1, 'b': 2, 'c': 10})
+        self.assertEqual(client.testOrder(a=10,b=11,c=12), 
+                         {'a': 10, 'b': 11, 'c': 12})
 

--- a/tornadorpc/utils.py
+++ b/tornadorpc/utils.py
@@ -49,11 +49,8 @@ def getcallargs(func, *positional, **named):
             else:
                 extra_args.append(value)
     if defaults:
-        reverse_args = args[:]
-#        reverse_args.reverse()
-        for i in range(len(defaults)):
-            arg_key = reverse_args[i]
-            final_kwargs.setdefault(arg_key, defaults[i])
+        for kwarg, default in zip(args[-len(defaults):], defaults):
+            final_kwargs.setdefault(kwarg, default)
     for arg in args:
         if arg not in final_kwargs:
             raise TypeError("Not all arguments supplied. (%s)", arg)

--- a/tornadorpc/utils.py
+++ b/tornadorpc/utils.py
@@ -50,7 +50,7 @@ def getcallargs(func, *positional, **named):
                 extra_args.append(value)
     if defaults:
         reverse_args = args[:]
-        reverse_args.reverse()
+#        reverse_args.reverse()
         for i in range(len(defaults)):
             arg_key = reverse_args[i]
             final_kwargs.setdefault(arg_key, defaults[i])


### PR DESCRIPTION
following up on my msg on the google groups, this is a fix for the order default arguments are set in. Currently they are set in reverse order as the following example shows:

server code:

from tornadorpc.json import JSONRPCHandler
from tornadorpc import start_server
class Handler(JSONRPCHandler):
    def test(self, a=1, b=2, c=3, d=4):
        return {'a': a, 'b': b, 'c': c, 'd': d}
start_server(Handler, port=8888)

client code:

import jsonrpclib
server = jsonrpclib.Server('http://localhost:8888')
print server.test()
print server.test(a='one')
print server.test(d='four')
print server.test(a='one',b='two',c='three',d='four')

This prints (unicode markers removed for readability):
{'a': 4, 'c': 2, 'b': 3, 'd': 1}
{'a': 'one', 'c': 2, 'b': 3, 'd': 1}
{'a': 4, 'c': 2, 'b': 3, 'd': 'four'}
{'a': 'one', 'c': 'three', 'b': 'two', 'd': 'four'}

note that the defaults are set in reverse order. My patch fixes this.
