### PR TITLE
import logging

### DIFF
--- a/tornadorpc/base.py
+++ b/tornadorpc/base.py
@@ -21,6 +21,8 @@ directly, but rather though the XML or JSON RPC implementations.
 You can use the utility functions like 'private' and 'start_server'.
 """
 
+import logging
+
 from tornado.web import RequestHandler
 import tornado.web
 import tornado.ioloop


### PR DESCRIPTION
Avoid this error when an async method returns non-None:

```
    Traceback (most recent call last):
      File "/Users/emptysquare/.virtualenvs/motor-blog/lib/python2.7/site-packages/tornado/web.py", line 1055, in _stack_context_handle_exception
        raise_exc_info((type, value, traceback))
      File "/Users/emptysquare/.virtualenvs/motor-blog/lib/python2.7/site-packages/tornado/web.py", line 1178, in wrapper
        result = method(self, *args, **kwargs)
      File "/Users/emptysquare/.virtualenvs/motor-blog/lib/python2.7/site-packages/tornadorpc/base.py", line 259, in post
        self._RPC_.run(self, request_body)
      File "/Users/emptysquare/.virtualenvs/motor-blog/lib/python2.7/site-packages/tornadorpc/base.py", line 103, in run
        self.dispatch(request[0], request[1])
      File "/Users/emptysquare/.virtualenvs/motor-blog/lib/python2.7/site-packages/tornadorpc/base.py", line 161, in dispatch
        logging.warning(message)
    NameError: global name 'logging' is not defined
```
