### PR TITLE
If the function returns a future, handle things asynchronously

### DIFF
--- a/tornadorpc/base.py
+++ b/tornadorpc/base.py
@@ -150,7 +150,10 @@ class BaseRPCParser(object):
                 def completer(future):
                     handler.result(future.result())
                 return completer
-            tornado.ioloop.IOLoop.instance().add_future(response, make_completer(self.handler))
+            if response.done():
+                return self.handler.result(response.result())
+            else:
+                tornado.ioloop.IOLoop.instance().add_future(response, make_completer(self.handler))
         elif getattr(method, 'async', False):
             # Asynchronous response -- the method should have called
             # self.result(RESULT_VALUE)

--- a/tornadorpc/base.py
+++ b/tornadorpc/base.py
@@ -142,9 +142,15 @@ class BaseRPCParser(object):
 
         from tornado.concurrent import Future
         if isinstance(response, Future):
-            def on_complete(future):
-                self.handler.result(future.result())
-            tornado.ioloop.IOLoop.instance().add_future(response, on_complete)
+            # self.handler is actually a transient: BaseRPCParser is used as a
+            # singleton class where self.handler changes each time a request is
+            # processed, so we need to treat it as a temporary, that may change
+            # anytime control flow returns to Tornado's IO handler
+            def make_completer(handler):
+                def completer(future):
+                    handler.result(future.result())
+                return completer
+            tornado.ioloop.IOLoop.instance().add_future(response, make_completer(self.handler))
         elif getattr(method, 'async', False):
             # Asynchronous response -- the method should have called
             # self.result(RESULT_VALUE)

--- a/tornadorpc/base.py
+++ b/tornadorpc/base.py
@@ -140,7 +140,12 @@ class BaseRPCParser(object):
             self.traceback(method_name, params)
             return self.handler.result(self.faults.internal_error())
 
-        if getattr(method, 'async', False):
+        from tornado.concurrent import Future
+        if isinstance(response, Future):
+            def on_complete(future):
+                self.handler.result(future.result())
+            tornado.ioloop.IOLoop.instance().add_future(response, on_complete)
+        elif getattr(method, 'async', False):
             # Asynchronous response -- the method should have called
             # self.result(RESULT_VALUE)
             if response is not None:


### PR DESCRIPTION
Currently I can use @async to make a xmlrpc server method asynchronous, but with tornado.gen and friends, I tried to make it so that I could use a @gen.coroutine instead. The first step was to make it so that if an xmlrpc method returns a Future, it is run asynchronously and its result is returned transparently.

Unfortunately, @gen.coroutines still cannot be used transparently, because the wrapper that they create confuses tornadorpc's getcallargs. Still, I find this change quite handy.

With regards to using gen.coroutines, at least now I can do this:

``` python
class RpcHandler(XMLRPCHandler):
    def foo(self):
        @gen.coroutine
        def run():
            result1 = yield something(1, 2, 3)
            result2 = yield somethingelse(3, 4, 5)
            raise gen.Return(result1 + result2)
        return run()
```
