### PR TITLE
Check length of args before popping first element

### DIFF
--- a/tornadorpc/utils.py
+++ b/tornadorpc/utils.py
@@ -19,7 +19,7 @@ def getcallargs(func, *positional, **named):
     final_kwargs = {}
     extra_args = []
     has_self = inspect.ismethod(func) and func.im_self is not None
-    if has_self:
+    if has_self and len(args) > 0:
         args.pop(0)
 
     # (Since our RPC supports only positional OR named.)


### PR DESCRIPTION
When I wanted to add a decorator of Basic HTTP Authentication to a method of a class, `getcallargs` thrown an exception.  

``` python
  File "/Users/admin/codes/rpc/tornadorpc/utils.py", line 26, in getcallargs
    args.pop(0)
IndexError: pop from empty list
```

Here's the test code:

``` python
import functools

def authtest(func):
    @functools.wraps(func)
    def wrapper(*args, **kwargs):
        func._need_authenticated = True
        return func(*args, **kwargs)
    return wrapper

class TestA(object):

    @authtest
    def category(self, slug):
        return 'Done'

class Handler(JSONRPCHandler):

    testa = TestA()

```
